### PR TITLE
fix: dont run preview if native project, VS Code workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 2.0.28
+
+- Fix for VSCode workspaces on Windows
+
 ### Version 2.0.27
 
 - Fix for running native projects opening web preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 2.0.27
+
+- Fix for running native projects opening web preview
+
 ### Version 2.0.26
 
 - Remove tests from extension output

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webnative",
-  "version": "2.0.25",
+  "version": "2.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webnative",
-      "version": "2.0.25",
+      "version": "2.0.27",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^3.21.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "icon": "media/webnative.png",
   "publisher": "WebNative",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "icon": "media/webnative.png",
   "publisher": "WebNative",
   "keywords": [

--- a/src/run-web.ts
+++ b/src/run-web.ts
@@ -71,7 +71,7 @@ async function runServe(
     defaultPort = undefined;
   }
 
-  if (webConfig.includes(WebConfigSetting.editor)) {
+  if (webConfig.includes(WebConfigSetting.editor) && !isNative) {
     const value: string = workspace.getConfiguration(WorkspaceSection).get('openPreviewLocation');
     exState.webView = viewInEditor('about:blank', value === 'tab');
   }


### PR DESCRIPTION
- Dont run preview if native project
- Fix VS Code workspaces on Windows