### PR TITLE
chore: change message of http recommendation

### DIFF
--- a/src/rules-capacitor.ts
+++ b/src/rules-capacitor.ts
@@ -97,8 +97,8 @@ export async function checkCapacitorRules(project: Project, context: ExtensionCo
   project.recommendReplace(
     'cordova-plugin-advanced-http',
     'cordova-plugin-advanced-http',
-    `Replace with @capacitor/http due to official support`,
-    `The plugin cordova-plugin-advanced-http should be replaced with @capacitor/http. Capacitor now provides the equivalent native http functionality built in.`,
+    `Replace with @capacitor/core due to official support`,
+    `The plugin cordova-plugin-advanced-http should be replaced with @capacitor/core. Capacitor now provides the equivalent native http functionality built in.`,
     '@capacitor/core',
   );
 


### PR DESCRIPTION
`@capacitor/http` is an existing package, which is deprecated, the messaging can be confusing and lead users to check or install the `@capacitor/http` package, the correct package to recommend is `@capacitor/core`