### PR TITLE
fix: android debugging option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 2.0.37
+
+- Option to set the Android debugging webroot to use the workspace folder or www folder
+
 ### Version 2.0.46
 
 - Set SigningType to ApkSigner by default when preparing Android builds

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "icon": "media/webnative.png",
   "publisher": "WebNative",
   "keywords": [
@@ -628,6 +628,16 @@
           ],
           "default": "",
           "description": "Whether to automatically import ion-icons for this project."
+        },
+        "webnative.androidDebugWebRoot": {
+          "type": "string",
+          "scope": "workspace",
+          "enum": [
+            "workspace",
+            "www"
+          ],
+          "default": "www",
+          "description": "Whether to set the android debugging webRoot to the workspace folder (for non-vite projects) or www folder."
         },
         "webnative.openPreviewLocation": {
           "type": "string",

--- a/src/android-debug.ts
+++ b/src/android-debug.ts
@@ -2,6 +2,7 @@ import { debug, workspace } from 'vscode';
 import { startSourceMapServer } from './source-map-server';
 import { debugSkipFiles } from './utilities';
 import { exState } from './wn-tree-provider';
+import { WorkspaceSection } from './workspace-state';
 
 // The debug provider type for VS Code
 export const AndroidDebugType = 'android-web';
@@ -22,13 +23,15 @@ export function debugAndroid(packageName: string, wwwFolder: string, projectFold
   // Note: options here include sourceMapPathOverrides and resolveSourceMapLocations both dont fix the
   // problem with source maps not being accessible to the debugger
   exState.debugged = true;
+  const value: string = workspace.getConfiguration(WorkspaceSection).get('androidDebugWebRoot');
+  const webRoot = value === 'www' ? wwwFolder : '${workspaceFolder}';
   debug.startDebugging(workspace.workspaceFolders[0], {
     type: AndroidDebugType,
     name: 'Debug Android',
     request: 'attach',
     packageName: packageName,
     platform: 'android',
-    webRoot: wwwFolder, //'${workspaceFolder}',
+    webRoot,
     sourceMaps: true,
 
     skipFiles: debugSkipFiles(),


### PR DESCRIPTION
This fixes #40 by giving an option to set the Android Debug webRoot to workspace.

<img width="818" height="187" alt="CleanShot 2025-10-12 at 08 46 15" src="https://github.com/user-attachments/assets/c115042e-0fbf-494a-a896-32b0ca259116" />
