### PR TITLE
Add browserslist update functionality for Angular migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 2.1.1
+
+- Migrate to Angular 21 now updates browserlist for compatibility
+
 ### Version 2.1.0
 
 - Support for Capacitor 8 migration

--- a/src/browserslist.ts
+++ b/src/browserslist.ts
@@ -1,0 +1,124 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { write } from './logging';
+import { Project } from './project';
+
+/**
+ * Updates browserslist configuration to meet specified browser requirements.
+ * Works with both .browserslistrc file and browserslist in package.json
+ *
+ * @param project - The project instance
+ * @param browsers - Array of browser requirements (e.g., ["Chrome >=107", "Firefox >=106"])
+ * @returns true if any updates were made, false otherwise
+ *
+ * @example
+ * const angular21Browsers = [
+ *   "Chrome >=107",
+ *   "Firefox >=106",
+ *   "Edge >=107",
+ *   "Safari >=16.1",
+ *   "iOS >=16.1"
+ * ];
+ * await updateBrowserslist(project, angular21Browsers);
+ */
+export function updateBrowserslist(project: Project, browsers: string[]): boolean {
+  const browserslistPath = join(project.projectFolder(), '.browserslistrc');
+  const packageJsonPath = join(project.projectFolder(), 'package.json');
+
+  // Create a map of browser patterns to their required versions
+  const browserMap = new Map<string, string>();
+  for (const browser of browsers) {
+    const match = browser.match(/^([A-Za-z]+)\s*>=/);
+    if (match) {
+      browserMap.set(match[1], browser);
+    }
+  }
+
+  // Try updating .browserslistrc first
+  if (existsSync(browserslistPath)) {
+    return updateBrowserslistFile(browserslistPath, browserMap);
+  }
+
+  // Fall back to updating package.json
+  return updatePackageJsonBrowserslist(packageJsonPath, browserMap);
+}
+
+/**
+ * Updates .browserslistrc file with new browser requirements
+ */
+function updateBrowserslistFile(filepath: string, browserMap: Map<string, string>): boolean {
+  try {
+    let content = readFileSync(filepath, 'utf8');
+    let updated = false;
+
+    // Replace existing browser entries or add new ones
+    for (const [browserName, browserVersion] of browserMap) {
+      const pattern = new RegExp(`^${browserName}\\s*>=\\s*[\\d.]+$`, 'm');
+
+      if (pattern.test(content)) {
+        content = content.replace(pattern, browserVersion);
+        updated = true;
+      } else if (!content.includes(browserVersion)) {
+        // Add the browser entry if it doesn't exist
+        content = content.trimEnd() + '\n' + browserVersion;
+        updated = true;
+      }
+    }
+
+    if (updated) {
+      writeFileSync(filepath, content);
+      write(`Updated ${filepath} with new browser requirements.`);
+      return true;
+    }
+  } catch (error) {
+    write(`Error updating .browserslistrc: ${error}`);
+  }
+
+  return false;
+}
+
+/**
+ * Updates browserslist in package.json with new browser requirements
+ */
+function updatePackageJsonBrowserslist(filepath: string, browserMap: Map<string, string>): boolean {
+  try {
+    if (!existsSync(filepath)) {
+      return false;
+    }
+
+    const packageJson = JSON.parse(readFileSync(filepath, 'utf8'));
+    const currentBrowserslist = packageJson.browserslist || [];
+    const newBrowserslist: string[] = [];
+    const processedBrowsers = new Set<string>();
+
+    // Update existing entries
+    for (const entry of currentBrowserslist) {
+      const match = entry.match(/^([A-Za-z]+)\s*>=/);
+      const browserName = match ? match[1] : null;
+
+      if (browserName && browserMap.has(browserName)) {
+        const newVersion = browserMap.get(browserName)!;
+        newBrowserslist.push(newVersion);
+        processedBrowsers.add(browserName);
+      } else {
+        newBrowserslist.push(entry);
+      }
+    }
+
+    // Add any missing required browsers
+    for (const [browserName, browserVersion] of browserMap) {
+      if (!processedBrowsers.has(browserName)) {
+        newBrowserslist.push(browserVersion);
+      }
+    }
+
+    packageJson.browserslist = newBrowserslist;
+    writeFileSync(filepath, JSON.stringify(packageJson, null, 2) + '\n');
+    write(`Updated browserslist in ${filepath} with new browser requirements.`);
+    return true;
+  } catch (error) {
+    write(`Error updating package.json browserslist: ${error}`);
+  }
+
+  return false;
+}

--- a/src/rules-angular-migrate.ts
+++ b/src/rules-angular-migrate.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { write } from './logging';
 import { join } from 'path';
 import { peerDependencyCleanup } from './peer-dependency-cleanup';
+import { updateBrowserslist } from './browserslist';
 
 // Maximum supported Angular version that we'll suggest migrating to
 export const maxAngularVersion = '21';
@@ -92,12 +93,10 @@ async function migrate(queueFunction: QueueFunction, project: Project, next: num
       });
     }
     if (version >= 16) {
-      replaceInFile(join(project.projectFolder(), '.browserslistrc'), {
-        replacements: [
-          { search: `Chrome >=60`, replace: `Chrome >=61` },
-          { search: `ChromeAndroid >=60`, replace: `ChromeAndroid >=61` },
-        ],
-      });
+      updateBrowserslist(project, ['Chrome >=61', 'ChromeAndroid >=60']);
+    }
+    if (version >= 21) {
+      updateBrowserslist(project, ['Chrome >=107', 'Firefox >=106', 'Edge >=107', 'Safari >=16.1', 'iOS >=16.1']);
     }
   }
 }


### PR DESCRIPTION
This pull request enhances the Angular migration process by introducing a more robust and flexible way to update browser compatibility settings during migrations, specifically for Angular 21. The main change is the addition of a new utility that updates the browserslist configuration in both `.browserslistrc` and `package.json`, ensuring compatibility with Angular 21's requirements. The migration logic now uses this utility for both Angular 16 and 21 upgrades, replacing the previous hardcoded string replacements.

**Migration improvements:**

* Added the `updateBrowserslist` utility in `src/browserslist.ts`, which updates browser requirements in either `.browserslistrc` or the `browserslist` field in `package.json`, supporting more flexible and maintainable browser compatibility updates.
* Updated the Angular migration logic in `src/rules-angular-migrate.ts` to use `updateBrowserslist` for Angular 16 and 21 migrations, replacing manual string replacements and adding support for the new browser requirements for Angular 21.

**Documentation:**

* Updated `CHANGELOG.md` to note that migrating to Angular 21 now updates browserslist for compatibility.

**Codebase maintenance:**

* Imported the new `updateBrowserslist` utility in `src/rules-angular-migrate.ts` to enable its use in migration scripts.