### PR TITLE
Add new commands to package.json for opening in browser and editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Version 2.1.1
 
 - Migrate to Angular 21 now updates browserlist for compatibility
+- Fix status bar items for running for web / debug (can now click without activating the extension)
 
 ### Version 2.1.0
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "whatsNewRevision": 1,
   "icon": "media/webnative.png",
   "publisher": "WebNative",
@@ -256,6 +256,14 @@
       {
         "command": "webnative.runWeb",
         "title": "WebNative:Run for Web"
+      },
+      {
+        "command": "webnative.openWeb",
+        "title": "WebNative:Open in Browser"
+      },
+      {
+        "command": "webnative.openEditor",
+        "title": "WebNative:Open in Editor"
       },
       {
         "command": "webnative.capSync",


### PR DESCRIPTION
This pull request updates the extension to version 2.1.1 and introduces improvements to status bar items and new commands. The most significant changes include fixing status bar item behavior for web/debug runs and adding new commands to open the project in a browser or editor.

Fixes #77 

**User Experience Improvements:**

* Fixed status bar items for running for web/debug so they can now be clicked without activating the extension.

**New Features:**

* Added new commands: `webnative.openWeb` ("WebNative:Open in Browser") and `webnative.openEditor` ("WebNative:Open in Editor") to the command palette.

**Versioning:**

* Bumped version to 2.1.1 in `package.json`.…ix #77)