### PR TITLE
fix: Add error handling for unknown serve commands in serveCmd function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 2.1.3
+
+- Handle where the serve command cannot be determined.
+
 ### Version 2.1.2
 
 - When you change package.json outside of the extension the UI will automatically update.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webnative",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webnative",
-      "version": "2.1.0",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^3.21.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "whatsNewRevision": 1,
   "icon": "media/webnative.png",
   "publisher": "WebNative",


### PR DESCRIPTION
This pull request updates the extension to version 2.1.3 and improves error handling when the serve command cannot be determined for a web project. The main changes focus on providing clearer feedback to users and preventing repeated error messages.

Error handling improvements:

* Added logic to display a user-friendly error message in the VS Code UI when the serve command cannot be determined, and ensured the message is only shown once per session (`src/web-run.ts`).
* Improved logging by showing output and providing a more descriptive error message when no serve/start/dev scripts are found in `package.json` (`src/web-run.ts`).
* Imported the `showOutput` function from `logging` to support enhanced error feedback (`src/web-run.ts`).
* Added a `serveUnknownMsg` flag to prevent repeated error messages during the same session (`src/web-run.ts`).

Versioning:

* Bumped the extension version to 2.1.3 in `package.json` and documented the change in `CHANGELOG.md`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6)