### PR TITLE
Add restart command and improve task handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### Version 2.2.1
+
+- Add "Restart" button alongside "Stop" button for running scripts to stop and restart the script
+- Replace stop button text with a stop icon ($(debug-stop))
+
 ### Version 2.2.0
 
 - Performance improvement to cache package information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add "Restart" button alongside "Stop" button for running scripts to stop and restart the script
 - Replace stop button text with a stop icon ($(debug-stop))
+- Fix clicking a running task to stop it immediately instead of queuing a new start
 
 ### Version 2.2.0
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "whatsNewRevision": 1,
   "icon": "media/webnative.png",
   "publisher": "WebNative",
@@ -292,7 +292,13 @@
       },
       {
         "command": "webnative.stop",
-        "title": "Stop"
+        "title": "Stop",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "webnative.restart",
+        "title": "Restart",
+        "icon": "$(debug-restart)"
       },
       {
         "command": "webnative.buildConfig",
@@ -485,6 +491,10 @@
         {
           "command": "webnative.stop",
           "when": "false"
+        },
+        {
+          "command": "webnative.restart",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -512,6 +522,11 @@
         },
         {
           "command": "webnative.stop",
+          "when": "view == wn-tree && viewItem == stop",
+          "group": "inline"
+        },
+        {
+          "command": "webnative.restart",
           "when": "view == wn-tree && viewItem == stop",
           "group": "inline"
         },

--- a/src/command-name.ts
+++ b/src/command-name.ts
@@ -7,6 +7,7 @@ export enum CommandName {
   Refresh = 'webnative.refresh',
   Add = 'webnative.add',
   Stop = 'webnative.stop',
+  Restart = 'webnative.restart',
   Rebuild = 'webnative.rebuild',
   RefreshDebug = 'webnative.refreshDebug',
   Function = 'webnative.function',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,6 +161,18 @@ export async function activate(context: ExtensionContext) {
     recommendation.setContext(undefined);
   });
 
+  commands.registerCommand(CommandName.Restart, async (recommendation: Recommendation) => {
+    const tip = recommendation.tip;
+    // Stop the running task
+    tip.data = Context.stop;
+    await fixIssue(undefined, context.extensionPath, ionicProvider, tip);
+    recommendation.setContext(undefined);
+    // Clear the stop data flag and wait for the process to fully terminate before restarting
+    tip.data = undefined;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    runAction(tip, ionicProvider, rootPath);
+  });
+
   commands.registerCommand(CommandName.OpenInXCode, async () => {
     await findAndRun(ionicProvider, rootPath, CommandTitle.OpenInXCode);
   });

--- a/src/features/fix-issue.ts
+++ b/src/features/fix-issue.ts
@@ -228,16 +228,17 @@ async function execute(tip: Tip, context: ExtensionContext): Promise<void> {
 }
 
 export async function runAction(tip: Tip, ionicProvider: ExTreeProvider, rootPath: string, srcCommand?: CommandName) {
+  // If this task is already running, stop it immediately instead of queuing
+  if ((tip.stoppable || tip.contextValue == Context.stop) && isRunning(tip)) {
+    cancelIfRunning(tip);
+    markActionAsCancelled(tip);
+    ionicProvider.refresh();
+    return;
+  }
   if (await waitForOtherActions(tip)) {
     return; // Canceled
   }
   if (tip.stoppable || tip.contextValue == Context.stop) {
-    if (isRunning(tip)) {
-      cancelIfRunning(tip);
-      markActionAsCancelled(tip);
-      ionicProvider.refresh();
-      return;
-    }
     markActionAsRunning(tip);
     ionicProvider.refresh();
   }


### PR DESCRIPTION
Introduce a "Restart" command for running scripts, allowing immediate stopping of tasks instead of queuing. Update the changelog for version 2.2.1 to reflect these changes.