### PR TITLE
fix: improve shell detection for Linux and nvm environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 2.2.6
 
+- Fix `npm run test` failures caused by `@webnativellc/simple-plist` ESM bundle requiring Node.js `stream` module: resolve to CJS bundle in vitest config
 - Fix `/bin/sh: npx: not found` on Linux and machines with nvm/homebrew Node.js: shell is now proactively detected at startup using VS Code terminal profile and `$SHELL`, and the error-handler fallback now uses the detected shell instead of hardcoded `/bin/zsh`
 
 ### Version 2.2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 2.2.6
+
+- Fix `/bin/sh: npx: not found` on Linux and machines with nvm/homebrew Node.js: shell is now proactively detected at startup using VS Code terminal profile and `$SHELL`, and the error-handler fallback now uses the detected shell instead of hardcoded `/bin/zsh`
+
 ### Version 2.2.5
 
 - Fix extension activation failure when `HTTPS_PROXY` is set: telemetry (Mixpanel) initialization is now lazy and non-fatal, so proxy environments no longer prevent command registration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "webnative",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webnative",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "MIT",
       "dependencies": {
-        "@webnativellc/simple-plist": "2.1.0",
+        "@webnativellc/simple-plist": "2.1.2",
         "fast-xml-parser": "5.7.3",
         "globule": "1.3.4",
         "htmlparser2": "^9.1.0",
@@ -2073,37 +2073,10 @@
       }
     },
     "node_modules/@webnativellc/simple-plist": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@webnativellc/simple-plist/-/simple-plist-2.1.0.tgz",
-      "integrity": "sha512-dGAbxmAOobm6JHSaBEg7qukFbrgG2rf3Rv39GZKsNUsTABLLTAnY2gz8fQM8vxFPc6KkxSKaHpi5v7vZuMG3Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "bplist-creator": "0.1.1",
-        "bplist-parser": "0.3.2",
-        "plist": "^5.0.0"
-      }
-    },
-    "node_modules/@webnativellc/simple-plist/node_modules/plist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-5.0.0.tgz",
-      "integrity": "sha512-20N+g1DvMm/DFRbsvER7tT4wDryq0WunK7VMkDaiJcKNapAnUMkTsAnacFYf8n420F4Hf6/hefgmJRkMb1M0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.9.10",
-        "xmlbuilder": "^15.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.6"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@webnativellc/simple-plist/-/simple-plist-2.1.2.tgz",
+      "integrity": "sha512-LNMg6IkVbKLowOM4z5E8ZcMXQvC8qQMWFkD+Q1s8a/bzNMlnuD1dZZ5nVxs/atabRgNpnTdytq+FLwSFRaFSYg==",
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -2157,27 +2130,6 @@
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/bplist-creator": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.1.tgz",
-      "integrity": "sha512-Ese7052fdWrxp/vqSJkydgx/1MdBnNOCV2XVfbmdGWD2H6EYza+Q4pyYSuVSnCUD22hfI/BFI4jHaC3NLXLlJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "stream-buffers": "2.2.x"
-      }
-    },
-    "node_modules/bplist-parser": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
-      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "big-integer": "1.6.x"
-      },
-      "engines": {
-        "node": ">= 5.10.0"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -736,7 +736,7 @@
     "vitest": "4.1.5"
   },
   "dependencies": {
-    "@webnativellc/simple-plist": "2.1.0",
+    "@webnativellc/simple-plist": "2.1.2",
     "fast-xml-parser": "5.7.3",
     "globule": "1.3.4",
     "htmlparser2": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "whatsNewRevision": 1,
   "icon": "media/webnative.png",
   "publisher": "WebNative",

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -11,6 +11,7 @@ import { join } from 'path';
 import { uncolor } from './uncolor';
 import { getStringFrom } from './utilities-strings';
 import { hideOutput } from './logging';
+import { guessShell } from './utilities-shell';
 
 interface ErrorLine {
   uri: string;
@@ -45,12 +46,13 @@ export async function handleError(error: string, logs: Array<string>, folder: st
   }
 
   if (error && error.startsWith('/bin/sh: npx')) {
-    const zsh = '/bin/zsh';
-    exState.shell = zsh;
-    exState.context.workspaceState.update(Context.shell, zsh);
+    const detectedShell = await guessShell(console.error);
+    const shell = detectedShell || '/bin/zsh';
+    exState.shell = shell;
+    exState.context.workspaceState.update(Context.shell, shell);
     const msg =
       'It looks like node was not found with the default shell so it has been switched to ' +
-      zsh +
+      shell +
       '. Please try the operation again.';
     await window.showErrorMessage(msg, 'OK');
     return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import { cancelAllOperations } from './tasks';
 import { trackProjectChange } from './features/track-project-changes';
 import { initializeTelemetry } from './telemetry';
 import { checkAndShowWhatsNew, showWhatsNew } from './whats-new';
+import { guessShell } from './utilities-shell';
 
 export const extensionName = 'WebNative';
 
@@ -129,6 +130,9 @@ export async function activate(context: ExtensionContext) {
   const shellOverride: string = workspace.getConfiguration(WorkspaceSection).get('shellPath');
   if (shellOverride && shellOverride.length > 0) {
     exState.shell = shellOverride;
+  }
+  if (!exState.shell) {
+    exState.shell = await guessShell(console.error);
   }
 
   trackProjectChange();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "sourceMap": true,
     "rootDir": "src",
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "types": ["node"]
   },
   "exclude": [
     "node_modules",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     setupFiles: ['./tests/setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@webnativellc/simple-plist': path.resolve(__dirname, 'node_modules/@webnativellc/simple-plist/dist/index.cjs'),
+    },
   },
 });


### PR DESCRIPTION
This pull request addresses an issue where the extension would fail with a `/bin/sh: npx: not found` error on Linux and systems using nvm or Homebrew-managed Node.js installations. The shell is now proactively detected at startup using the VS Code terminal profile and `$SHELL`, and the error handler fallback now uses the detected shell instead of hardcoding `/bin/zsh`. The extension version is also bumped to 2.2.6.

Shell detection and error handling improvements:

* Added proactive shell detection at startup using the VS Code terminal profile and `$SHELL` in `src/extension.ts` and `src/error-handler.ts`, ensuring the correct shell is used for running commands. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R39) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R134-R136) [[3]](diffhunk://#diff-16ac16a61ba525adf20e3b7572fb4e51366df6f441c9ec89602c7bd9d7cb30bcR14)
* Updated the error handler in `src/error-handler.ts` to use the detected shell (or fallback to `/bin/zsh`) when handling `/bin/sh: npx` errors, improving compatibility on Linux and with nvm/Homebrew Node.js setups.

Versioning and documentation:

* Updated `CHANGELOG.md` to document the fix and released version 2.2.6.
* Bumped the extension version to 2.2.6 in `package.json`.