### PR TITLE
chore: update version to 2.2.9 and enhance build/serve command detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### Version 2.2.9
+
+- Fix build command to use `wn:build`, then `ionic:build`, then `build` from package.json for all framework types, instead of hardcoding `vite build`
+- Fix serve command to use `wn:serve`, then `ionic:serve`, then `serve`/`dev`/`start` from package.json for all framework types, instead of hardcoding `vite`
+
 ### Version 2.2.8
 
 - Update shellOverride. If set to \* will guess the shell.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "whatsNewRevision": 1,
   "icon": "media/webnative.png",
   "publisher": "WebNative",

--- a/src/build.ts
+++ b/src/build.ts
@@ -67,7 +67,7 @@ function runBuild(
 ): string {
   let cmd = `${npx(project)} ${buildCmd(project)}`;
   if (configurationArg) {
-    if (cmd.includes('npm run ionic:build')) {
+    if (cmd.includes('wn:build') || cmd.includes('ionic:build')) {
       // This adds -- if the command is npm run build but does not if it is something like ng build
       cmd += ' -- --';
     } else if (cmd.includes('run ')) {
@@ -90,12 +90,15 @@ function runBuild(
 }
 
 function buildCmd(project: Project): string {
+  const guessed = guessBuildCommand(project);
+  if (guessed) {
+    return guessed;
+  }
   switch (project.frameworkType) {
     case 'angular':
     case 'angular-standalone':
-      return guessBuildCommand(project) ?? 'ng build';
+      return 'ng build';
     case 'vue-vite':
-      return guessBuildCommand(project) ?? 'vite build';
     case 'react-vite':
       return 'vite build';
     case 'react':
@@ -103,11 +106,8 @@ function buildCmd(project: Project): string {
     case 'vue':
       return 'vue-cli-service build';
     default: {
-      const cmd = guessBuildCommand(project);
-      if (!cmd) {
-        error('build command is unknown');
-      }
-      return cmd;
+      error('build command is unknown');
+      return '';
     }
   }
 }
@@ -116,9 +116,11 @@ function guessBuildCommand(project: Project): string | undefined {
   const filename = join(project.projectFolder(), 'package.json');
   if (existsSync(filename)) {
     const packageFile = JSON.parse(readFileSync(filename, 'utf8'));
-    if (packageFile.scripts['ionic:build']) {
+    if (packageFile.scripts?.['wn:build']) {
+      return npmRun('wn:build');
+    } else if (packageFile.scripts?.['ionic:build']) {
       return npmRun('ionic:build');
-    } else if (packageFile.scripts['build']) {
+    } else if (packageFile.scripts?.['build']) {
       return npmRun('build');
     }
   }

--- a/src/web-run.ts
+++ b/src/web-run.ts
@@ -124,6 +124,10 @@ async function runServe(
 let serveUnknownMsg = false;
 
 function serveCmd(project: Project): string {
+  const guessed = guessServeCommand(project);
+  if (guessed) {
+    return guessed + ' -- ';
+  }
   switch (project.frameworkType) {
     case 'angular':
     case 'angular-standalone':
@@ -136,9 +140,8 @@ function serveCmd(project: Project): string {
     case 'vue':
       return 'vue-cli-service serve';
     default: {
-      const cmd = guessServeCommand(project);
-      if (cmd) {
-        return cmd + ' -- ';
+      if (exists('vite')) {
+        return 'vite';
       }
       if (!serveUnknownMsg) {
         window.showErrorMessage(
@@ -158,7 +161,9 @@ function guessServeCommand(project: Project): string | undefined {
   const filename = join(project.projectFolder(), 'package.json');
   if (existsSync(filename)) {
     const packageFile = JSON.parse(readFileSync(filename, 'utf8'));
-    if (packageFile.scripts['ionic:serve']) {
+    if (packageFile.scripts?.['wn:serve']) {
+      return npmRun('wn:serve');
+    } else if (packageFile.scripts?.['ionic:serve']) {
       return npmRun('ionic:serve');
     } else if (packageFile.scripts?.serve) {
       return npmRun('serve');
@@ -166,8 +171,6 @@ function guessServeCommand(project: Project): string | undefined {
       return npmRun('dev');
     } else if (packageFile.scripts?.start) {
       return npmRun('start');
-    } else if (exists('vite')) {
-      return 'vite';
     }
   }
   return undefined;


### PR DESCRIPTION
This pull request updates the way build and serve commands are determined for all framework types, making the process more flexible and less dependent on hardcoded defaults. Instead of always using specific commands like `vite build` or `vite`, the logic now prioritizes custom scripts (`wn:build`, `ionic:build`, etc.) from `package.json` if available, and falls back to appropriate defaults. The version is also bumped to 2.2.9.

**Build and Serve Command Improvements:**

* The build process now checks for `wn:build`, `ionic:build`, and then `build` scripts in `package.json` for all frameworks, instead of always using `vite build`. This allows for more customization and compatibility with different project setups. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7) [[2]](diffhunk://#diff-f065c431b4f45758b2e047fcd38135fdcb2327564def7a33ab41e84898210fc8L70-R70) [[3]](diffhunk://#diff-f065c431b4f45758b2e047fcd38135fdcb2327564def7a33ab41e84898210fc8R93-R110) [[4]](diffhunk://#diff-f065c431b4f45758b2e047fcd38135fdcb2327564def7a33ab41e84898210fc8L119-R123)
* The serve process now checks for `wn:serve`, `ionic:serve`, `serve`, `dev`, and `start` scripts in `package.json`, instead of always using `vite`. This also increases flexibility and supports a wider range of project configurations. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7) [[2]](diffhunk://#diff-f4d097982caaf8d921659ccabb04fadc9cb5e274e710ac434b93e90b4ae942b7R127-R130) [[3]](diffhunk://#diff-f4d097982caaf8d921659ccabb04fadc9cb5e274e710ac434b93e90b4ae942b7L139-R144) [[4]](diffhunk://#diff-f4d097982caaf8d921659ccabb04fadc9cb5e274e710ac434b93e90b4ae942b7L161-L170)

**Versioning:**

* Bumped the package version to 2.2.9 in `package.json` and updated the changelog to reflect the new command resolution logic. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7)