### PR TITLE
Bump version to 2.2.10 and update max supported Angular version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "whatsNewRevision": 1,
   "icon": "media/webnative.png",
   "publisher": "WebNative",

--- a/src/rules-angular-migrate.ts
+++ b/src/rules-angular-migrate.ts
@@ -13,7 +13,7 @@ import { peerDependencyCleanup } from './peer-dependency-cleanup';
 import { updateBrowserslist } from './browserslist';
 
 // Maximum supported Angular version that we'll suggest migrating to
-export const maxAngularVersion = '21';
+export const maxAngularVersion = '22';
 
 export function angularMigrate(project: Project, latestVersion: string): Tip | undefined {
   const current = getPackageVersion('@angular/core');


### PR DESCRIPTION
This pull request contains minor updates to keep the project current. The main changes are a version bump for the package and an update to the maximum supported Angular version in the migration logic.

Versioning and compatibility updates:

* Increased the package version in `package.json` from `2.2.9` to `2.2.10`.
* Updated the `maxAngularVersion` constant in `src/rules-angular-migrate.ts` from `'21'` to `'22'`, so migration tips will now suggest Angular 22 as the latest supported version.