### PR TITLE
chore: bump version to 2.2.13 and add Angular optional migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 ## Changelog
 
+### Version 2.2.13
+
+- Angular optional migrations added to project menu
+- Migration for deprecated typescript settings
+
 ### Version 2.2.11
 
+- Add Angular 22+ migration options in Advanced Actions for Karma to Vitest and Application Builder
+- Fix Angular schematic migrations running outside the workspace by using the project folder and package-manager-aware ng invocation
 - Fix Angular migration to verify dependencies before `ng update`, offer `node_modules` reinstall when out of sync, warn on dirty git and monorepo subprojects, and skip post-migration steps on failure
 - Fix Angular migration running peer dependency cleanup that could suggest downgrading `@angular/*` packages after a successful update
 - Fix duplicate browserslist updates during Angular migration
@@ -11,6 +18,9 @@
 - Suppress the install node_modules prompt during Angular migration while `ng update` reinstalls dependencies
 - Show the Angular migration recommendation in Recommendations for all Angular projects, not only Capacitor apps
 - Remove deprecated TypeScript `baseUrl` and `downlevelIteration` options from Angular subproject tsconfigs to fix build failures with TypeScript 5.9+
+- Fix deprecated TypeScript config cleanup to follow tsconfig `extends` chains and angular.json references in monorepos
+- Fix deprecated TypeScript config cleanup to include parent-folder and repo-root tsconfig files for subfolder Angular projects
+- Add a recommendation to fix deprecated TypeScript compiler options when detected in project tsconfigs
 
 ### Version 2.2.9
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webnative",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webnative",
-      "version": "2.2.11",
+      "version": "2.2.12",
       "license": "MIT",
       "dependencies": {
         "@webnativellc/simple-plist": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.2.11",
+  "version": "2.2.13",
   "whatsNewRevision": 1,
   "icon": "media/webnative.png",
   "publisher": "WebNative",

--- a/src/advanced-actions.ts
+++ b/src/advanced-actions.ts
@@ -1,5 +1,5 @@
 import { Project } from './project';
-import { PackageManager, npmInstall, npmInstallAll } from './node-commands';
+import { PackageManager, npmInstall, npmInstallAll, npx } from './node-commands';
 import { confirm, getRunOutput, isWindows, replaceAll } from './utilities';
 import { write, writeError, writeWN } from './logging';
 import { exists, isGreaterOrEqual, isLess } from './analyzer';
@@ -10,6 +10,7 @@ import { CommandName, InternalCommand } from './command-name';
 import { ProgressLocation, QuickPickItem, QuickPickItemKind, commands, window } from 'vscode';
 import { sep } from 'path';
 import { integratePrettier } from './prettier';
+import { fixDeprecatedTsconfigOptions } from './rules-typescript-config';
 
 enum Features {
   migrateToPNPM = '$(find-replace) Migrate to PNPM',
@@ -55,20 +56,32 @@ const angularSchematics: AngularSchematic[] = [
     name: '$(test-view-icon) Migrate to replace @Output with Output functions',
     minimumVersion: '19.0.0',
     description: 'This will replace your @Output decorators with Output functions. Are you sure?',
-    command: `ng generate @angular/core:output-migration --interactive=false --defaults=true --path=".${sep}"`,
+    command: `npx ng generate @angular/core:output-migration --interactive=false --defaults=true --path=".${sep}"`,
   },
   {
     name: '$(test-view-icon) Migrate to use inject for dependency injection',
     minimumVersion: '19.0.0',
     description: 'This will replace dependency injection to use the inject function. Are you sure?',
-    command: `ng generate @angular/core:inject --interactive=false --defaults=true --path=".${sep}"`,
+    command: `npx ng generate @angular/core:inject --interactive=false --defaults=true --path=".${sep}"`,
   },
   {
     name: '$(test-view-icon) Migrate ViewChild and ContentChild to use signals',
     minimumVersion: '19.0.0',
     description:
       'This will replace @ViewChild and @ContentChild decorators with the equivalent signal query. Are you sure?',
-    command: `ng generate @angular/core:signal-queries --interactive=false --defaults=true --path=".${sep}"`,
+    command: `npx ng generate @angular/core:signal-queries --interactive=false --defaults=true --path=".${sep}"`,
+  },
+  {
+    name: '$(test-view-icon) Migrate Karma to Vitest',
+    minimumVersion: '22.0.0',
+    description: 'This will migrate your Karma test configuration to Vitest. Are you sure?',
+    command: 'ng update @angular/cli --name migrate-karma-to-vitest',
+  },
+  {
+    name: '$(test-view-icon) Migrate to Use Application Builder',
+    minimumVersion: '22.0.0',
+    description: 'This will migrate your project to use the application builder. Are you sure?',
+    command: 'ng update @angular/cli --name use-application-builder',
   },
 ];
 
@@ -157,9 +170,22 @@ async function angularSchematic(selection: string, project: Project) {
     await migration.commandFn(selection, project);
     return;
   } else {
-    const commands = [migration.command];
-    await runCommands(commands, selection, project);
+    const commands = [qualifyAngularCommand(migration.command, project)];
+    const success = await runCommands(commands, selection, project, project.projectFolder());
+    if (success) {
+      fixDeprecatedTsconfigOptions(project);
+    }
   }
+}
+
+function qualifyAngularCommand(command: string, project: Project): string {
+  if (command.startsWith('npx ')) {
+    return command.replace('npx ', `${npx(project)} `);
+  }
+  if (command.startsWith('ng ')) {
+    return `${npx(project)} ${command}`;
+  }
+  return command;
 }
 
 function migrateToPNPM(): Array<string> {
@@ -202,14 +228,19 @@ function showIgnoredRecommendations(): void {
   commands.executeCommand(CommandName.Refresh);
 }
 
-export async function runCommands(commands: Array<string>, title: string, project: Project): Promise<boolean> {
+export async function runCommands(
+  commands: Array<string>,
+  title: string,
+  project: Project,
+  folder?: string,
+): Promise<boolean> {
   try {
     if (title.includes(')')) {
       title = title.substring(title.indexOf(')') + 1);
     }
     let success = false;
     await window.withProgress({ location: ProgressLocation.Notification, title, cancellable: false }, async () => {
-      success = await run(commands, project.folder);
+      success = await run(commands, folder ?? project.folder);
     });
 
     if (success) {

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -35,6 +35,7 @@ import { analyzeSize } from './analyze-size';
 import { ionicExport } from './ionic-export';
 import { addAngularGenerateAction } from './angular-generate';
 import { addAngularMigrationRecommendation } from './rules-angular-migrate';
+import { addDeprecatedTsconfigRecommendation } from './rules-typescript-config';
 import { LoggingSettings } from './log-settings';
 import { writeWN } from './logging';
 import { cancelLastOperation } from './tasks';
@@ -317,6 +318,7 @@ export async function getRecommendations(project: Project, context: ExtensionCon
   );
 
   addAngularMigrationRecommendation(project);
+  addDeprecatedTsconfigRecommendation(project);
 
   // General Rules around node modules (eg Jquery)
   checkPackages(project);

--- a/src/rules-angular-migrate.ts
+++ b/src/rules-angular-migrate.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { write, writeError } from './logging';
 import { join } from 'path';
 import { updateBrowserslist } from './browserslist';
+import { fixDeprecatedTsconfigOptions } from './rules-typescript-config';
 import { CommandName, InternalCommand } from './command-name';
 import { exState } from './tree-provider';
 import { MonoRepoType } from './monorepo';
@@ -110,10 +111,10 @@ async function migrate(queueFunction: QueueFunction, project: Project, next: num
         commands.push(npmInstall(list.join(' '), '--force'));
       }
       const success = await runCommands(commands, `Migrating to Angular ${version}`, project);
+      postFixes(project, version);
       if (!success) {
         return;
       }
-      postFixes(project, version);
       await refreshProject(project);
       logOptionalMigrations(version);
       await suggestOtherAngularMigrations(project, version);
@@ -127,6 +128,7 @@ async function migrate(queueFunction: QueueFunction, project: Project, next: num
   }
 
   function postFixes(project: Project, version: number) {
+    fixDeprecatedTsconfigOptions(project);
     if (version == 17) {
       // Fix polyfills.ts
       replaceInFile(join(project.projectFolder(), 'src', 'polyfills.ts'), {

--- a/src/rules-typescript-config.ts
+++ b/src/rules-typescript-config.ts
@@ -1,0 +1,233 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { stripJsonComments } from './strip-json-comments';
+import { write } from './logging';
+import { Project } from './project';
+import { QueueFunction, Tip, TipType } from './tip';
+import { isGreaterOrEqual } from './analyzer';
+
+interface CompilerOptions {
+  baseUrl?: string;
+  downlevelIteration?: boolean;
+  paths?: Record<string, string[]>;
+  [key: string]: unknown;
+}
+
+interface TsConfig {
+  extends?: string;
+  compilerOptions?: CompilerOptions;
+  [key: string]: unknown;
+}
+
+interface AngularProject {
+  root?: string;
+  architect?: Record<string, { options?: { tsConfig?: string } }>;
+}
+
+export function joinBaseUrlPath(baseUrl: string, pathValue: string): string {
+  if (pathValue.startsWith('./') || pathValue.startsWith('../')) {
+    return pathValue;
+  }
+  const base = baseUrl.replace(/\/$/, '') || '.';
+  if (base === '.' || base === './') {
+    return pathValue.startsWith('.') ? pathValue : `./${pathValue}`;
+  }
+  const combined = `${base}/${pathValue}`.replace(/\/+/g, '/');
+  return combined.startsWith('.') ? combined : `./${combined}`;
+}
+
+export function hasDeprecatedCompilerOptions(compilerOptions?: CompilerOptions): boolean {
+  if (!compilerOptions) {
+    return false;
+  }
+  return compilerOptions.baseUrl !== undefined || compilerOptions.downlevelIteration !== undefined;
+}
+
+export function migrateCompilerOptions(compilerOptions: CompilerOptions): boolean {
+  let changed = false;
+
+  if (compilerOptions.downlevelIteration !== undefined) {
+    delete compilerOptions.downlevelIteration;
+    changed = true;
+  }
+
+  const baseUrl = compilerOptions.baseUrl;
+  if (baseUrl !== undefined) {
+    if (compilerOptions.paths) {
+      const newPaths: Record<string, string[]> = {};
+      for (const [key, values] of Object.entries(compilerOptions.paths)) {
+        newPaths[key] = values.map((value) => joinBaseUrlPath(baseUrl, value));
+      }
+      compilerOptions.paths = newPaths;
+    }
+    delete compilerOptions.baseUrl;
+    changed = true;
+  }
+
+  return changed;
+}
+
+function readTsconfig(filename: string): TsConfig | undefined {
+  if (!existsSync(filename)) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(stripJsonComments(readFileSync(filename, 'utf8')));
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveTsconfigPath(fromFile: string, extendsPath: string): string {
+  let resolved = resolve(dirname(fromFile), extendsPath);
+  if (!existsSync(resolved) && !resolved.endsWith('.json')) {
+    const withJson = `${resolved}.json`;
+    if (existsSync(withJson)) {
+      resolved = withJson;
+    }
+  }
+  return resolved;
+}
+
+export function collectTsconfigSearchDirs(project: Project): string[] {
+  const projectFolder = project.projectFolder();
+  const repoRoot = project.folder;
+  const dirs = [projectFolder];
+
+  const parent = dirname(projectFolder);
+  if (parent !== projectFolder && !dirs.includes(parent)) {
+    dirs.push(parent);
+  }
+
+  if (repoRoot !== projectFolder && !dirs.includes(repoRoot)) {
+    dirs.push(repoRoot);
+  }
+
+  return dirs;
+}
+
+function collectTsconfigFilesInDir(folder: string, files: Set<string>): void {
+  if (!existsSync(folder)) {
+    return;
+  }
+  for (const entry of readdirSync(folder, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.startsWith('tsconfig') && entry.name.endsWith('.json')) {
+      files.add(join(folder, entry.name));
+    }
+  }
+}
+
+function collectExtendedTsconfigs(filename: string, files: Set<string>): void {
+  const tsconfig = readTsconfig(filename);
+  const extendsPath = tsconfig?.extends;
+  if (typeof extendsPath !== 'string') {
+    return;
+  }
+  const parent = resolveTsconfigPath(filename, extendsPath);
+  if (!files.has(parent)) {
+    files.add(parent);
+    collectExtendedTsconfigs(parent, files);
+  }
+}
+
+function findAngularJsonPaths(project: Project): string[] {
+  const paths: string[] = [];
+  for (const candidate of [join(project.projectFolder(), 'angular.json'), join(project.folder, 'angular.json')]) {
+    if (existsSync(candidate) && !paths.includes(candidate)) {
+      paths.push(candidate);
+    }
+  }
+  return paths;
+}
+
+function collectTsconfigFromAngularJson(angularJsonPath: string, files: Set<string>, projectName?: string): void {
+  const angular = readTsconfig(angularJsonPath) as { projects?: Record<string, AngularProject> } | undefined;
+  if (!angular?.projects) {
+    return;
+  }
+  const angularDir = dirname(angularJsonPath);
+  const projects =
+    projectName && angular.projects[projectName] ? { [projectName]: angular.projects[projectName] } : angular.projects;
+
+  for (const prj of Object.values(projects)) {
+    const projectRoot = join(angularDir, prj.root ?? '');
+    for (const target of Object.values(prj.architect ?? {})) {
+      const tsConfig = target.options?.tsConfig;
+      if (typeof tsConfig === 'string') {
+        files.add(resolve(projectRoot, tsConfig));
+      }
+    }
+  }
+}
+
+function collectAllTsconfigFiles(project: Project): Set<string> {
+  const files = new Set<string>();
+
+  for (const folder of collectTsconfigSearchDirs(project)) {
+    collectTsconfigFilesInDir(folder, files);
+  }
+  for (const angularJson of findAngularJsonPaths(project)) {
+    collectTsconfigFromAngularJson(angularJson, files, project.monoRepo?.name);
+  }
+
+  for (const file of [...files]) {
+    collectExtendedTsconfigs(file, files);
+  }
+
+  return files;
+}
+
+function fixTsconfigFile(filename: string): boolean {
+  if (!existsSync(filename)) {
+    return false;
+  }
+  const before = readFileSync(filename, 'utf8');
+  const tsconfig = readTsconfig(filename);
+  if (!tsconfig?.compilerOptions || !migrateCompilerOptions(tsconfig.compilerOptions)) {
+    return false;
+  }
+
+  const commentMatch = before.match(/^\/\*[\s\S]*?\*\/\s*\n/);
+  const header = commentMatch ? commentMatch[0] : '';
+  writeFileSync(filename, `${header}${JSON.stringify(tsconfig, null, 2)}\n`);
+  write(`Updated ${filename} to remove deprecated TypeScript compiler options.`);
+  return true;
+}
+
+export function hasDeprecatedTsconfigInProject(project: Project): boolean {
+  for (const file of collectAllTsconfigFiles(project)) {
+    const tsconfig = readTsconfig(file);
+    if (hasDeprecatedCompilerOptions(tsconfig?.compilerOptions)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function fixDeprecatedTsconfigOptions(project: Project): void {
+  for (const file of collectAllTsconfigFiles(project)) {
+    fixTsconfigFile(file);
+  }
+}
+
+export function addDeprecatedTsconfigRecommendation(project: Project): void {
+  if (!isGreaterOrEqual('@angular/core', '12.0.0')) {
+    return;
+  }
+  if (!hasDeprecatedTsconfigInProject(project)) {
+    return;
+  }
+  project.add(
+    new Tip(
+      'Fix deprecated TypeScript compiler options',
+      'Remove baseUrl and downlevelIteration from tsconfig files for TypeScript 5.9+ compatibility',
+      TipType.Error,
+    ).setQueuedAction(fixDeprecatedTsconfig, project),
+  );
+}
+
+function fixDeprecatedTsconfig(queueFunction: QueueFunction, project: Project): Promise<void> {
+  queueFunction();
+  fixDeprecatedTsconfigOptions(project);
+  return Promise.resolve();
+}

--- a/tests/rules-typescript-config.test.ts
+++ b/tests/rules-typescript-config.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { Project } from '../src/project';
+import {
+  collectTsconfigSearchDirs,
+  fixDeprecatedTsconfigOptions,
+  hasDeprecatedCompilerOptions,
+  hasDeprecatedTsconfigInProject,
+  joinBaseUrlPath,
+  migrateCompilerOptions,
+} from '../src/rules-typescript-config';
+
+test('joinBaseUrlPath prefixes paths relative to baseUrl', () => {
+  expect(joinBaseUrlPath('./src', 'app/*')).toBe('./src/app/*');
+  expect(joinBaseUrlPath('.', 'src/app/*')).toBe('./src/app/*');
+  expect(joinBaseUrlPath('./', 'src/app/*')).toBe('./src/app/*');
+});
+
+test('joinBaseUrlPath leaves explicit relative paths unchanged', () => {
+  expect(joinBaseUrlPath('./src', './app/*')).toBe('./app/*');
+  expect(joinBaseUrlPath('./src', '../lib/*')).toBe('../lib/*');
+});
+
+test('migrateCompilerOptions removes deprecated options and rewrites paths', () => {
+  const compilerOptions = {
+    baseUrl: './src',
+    downlevelIteration: true,
+    paths: {
+      '@app/*': ['app/*'],
+      '@lib/*': ['./lib/*'],
+    },
+  };
+
+  expect(migrateCompilerOptions(compilerOptions)).toBe(true);
+  expect(compilerOptions).toEqual({
+    paths: {
+      '@app/*': ['./src/app/*'],
+      '@lib/*': ['./lib/*'],
+    },
+  });
+});
+
+test('migrateCompilerOptions removes baseUrl when paths are absent', () => {
+  const compilerOptions = {
+    baseUrl: './',
+    downlevelIteration: true,
+  };
+
+  expect(migrateCompilerOptions(compilerOptions)).toBe(true);
+  expect(compilerOptions).toEqual({});
+});
+
+test('hasDeprecatedCompilerOptions detects deprecated compiler options', () => {
+  expect(hasDeprecatedCompilerOptions({ baseUrl: './' })).toBe(true);
+  expect(hasDeprecatedCompilerOptions({ downlevelIteration: true })).toBe(true);
+  expect(hasDeprecatedCompilerOptions({ paths: { '@app/*': ['./src/*'] } })).toBe(false);
+});
+
+test('collectTsconfigSearchDirs includes parent folder and repo root', () => {
+  const project = {
+    folder: '/repo',
+    projectFolder: () => '/repo/admin-app',
+  } as Project;
+
+  expect(collectTsconfigSearchDirs(project)).toEqual(['/repo/admin-app', '/repo']);
+});
+
+test('fixDeprecatedTsconfigOptions fixes parent-folder tsconfig for subfolder projects', () => {
+  const root = mkdtempSync(join(tmpdir(), 'tsconfig-subfolder-'));
+  const appDir = join(root, 'admin-app');
+  try {
+    writeFileSync(
+      join(root, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: { baseUrl: './', downlevelIteration: true },
+      }),
+    );
+    mkdirSync(appDir);
+    writeFileSync(
+      join(appDir, 'tsconfig.json'),
+      JSON.stringify({
+        extends: '../tsconfig.json',
+        compilerOptions: { strict: true },
+      }),
+    );
+
+    const project = { folder: root, projectFolder: () => appDir } as Project;
+    expect(hasDeprecatedTsconfigInProject(project)).toBe(true);
+    fixDeprecatedTsconfigOptions(project);
+    expect(hasDeprecatedTsconfigInProject(project)).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('fixDeprecatedTsconfigOptions follows extends chain', () => {
+  const root = mkdtempSync(join(tmpdir(), 'tsconfig-test-'));
+  try {
+    writeFileSync(
+      join(root, 'tsconfig.base.json'),
+      JSON.stringify({
+        compilerOptions: { baseUrl: './', downlevelIteration: true },
+      }),
+    );
+    writeFileSync(
+      join(root, 'tsconfig.json'),
+      JSON.stringify({
+        extends: './tsconfig.base.json',
+        compilerOptions: { strict: true },
+      }),
+    );
+
+    const project = { folder: root, projectFolder: () => root } as Project;
+    expect(hasDeprecatedTsconfigInProject(project)).toBe(true);
+    fixDeprecatedTsconfigOptions(project);
+    expect(hasDeprecatedTsconfigInProject(project)).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -11,6 +11,7 @@ vi.mock('vscode', () => {
       showQuickPick: vi.fn(),
       activeTextEditor: null,
       withProgress: vi.fn(),
+      createOutputChannel: vi.fn(() => ({ appendLine: vi.fn(), show: vi.fn() })),
     },
     commands: {
       executeCommand: vi.fn(),


### PR DESCRIPTION
- Added Angular optional migrations to the project menu
- Implemented migration for deprecated TypeScript settings
- Updated package version in package.json and package-lock.json
- Enhanced Angular migration commands to use npx for better compatibility
- Added recommendations for fixing deprecated TypeScript compiler options