### PR TITLE
fix: background refresh to update projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### Version 2.2.10
+
+- Stop infinite npm outdated/list loops by deduping in-flight package refreshes and not re-triggering solely because the cached list is empty after a recent attempt
+- Fix TypeScript Problems in tree-provider by making lazily initialized ExState fields optional
+- Fix TypeScript Problems in process-packages (strict typing for package maps, error handling, and optional cache-key Project args)
+- Allow package/project cache key helpers to be called without a Project so clearRefreshCache can match all workspace-scoped keys by prefix
+- Return project inspection results immediately, then refresh outdated package data in a second background pass cached per selected workspace and trigger a UI refresh when that data arrives
+
 ### Version 2.2.9
 
 - Fix build command to use `wn:build`, then `ionic:build`, then `build` from package.json for all framework types, instead of hardcoding `vite build`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webnative",
-  "version": "2.2.6",
+  "version": "2.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webnative",
-      "version": "2.2.6",
+      "version": "2.2.9",
       "license": "MIT",
       "dependencies": {
         "@webnativellc/simple-plist": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webnative",
   "displayName": "WebNative",
   "description": "Create and maintain web and native projects",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "whatsNewRevision": 1,
   "icon": "media/webnative.png",
   "publisher": "WebNative",

--- a/src/context-variables.ts
+++ b/src/context-variables.ts
@@ -64,28 +64,28 @@ export enum VSCommand {
   setContext = 'setContext',
 }
 
-export function PackageCacheOutdated(project: Project) {
+export function PackageCacheOutdated(project?: Project) {
   if (project?.monoRepo?.localPackageJson) {
     return 'npmOutdatedData_' + project.monoRepo.name;
   }
   return 'npmOutdatedData';
 }
 
-export function PackageCacheList(project: Project) {
+export function PackageCacheList(project?: Project) {
   if (project?.monoRepo?.localPackageJson) {
     return 'npmListData_' + project.monoRepo.name;
   }
   return 'npmListData';
 }
 
-export function CapProjectCache(project: Project) {
+export function CapProjectCache(project?: Project) {
   if (project?.monoRepo?.localPackageJson) {
     return 'CapacitorProject_' + project.monoRepo.name;
   }
   return 'CapacitorProject';
 }
 
-export function PackageCacheModified(project: Project) {
+export function PackageCacheModified(project?: Project) {
   if (project?.monoRepo?.localPackageJson) {
     return 'packagesModified_' + project.monoRepo.name;
   }
@@ -94,7 +94,7 @@ export function PackageCacheModified(project: Project) {
 
 export const LastManifestCheck = 'LastManifestCheck';
 
-export function PackageCacheRefreshedAt(project: Project) {
+export function PackageCacheRefreshedAt(project?: Project) {
   if (project?.monoRepo?.localPackageJson) {
     return 'packageRefreshedAt_' + project.monoRepo.name;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,6 +113,7 @@ export async function activate(context: ExtensionContext) {
   exState.view = view;
   exState.projectsView = projectsView;
   exState.context = context;
+  exState.refreshTree = () => ionicProvider.refresh();
 
   // Initialize anonymous telemetry - non-fatal so proxy environments don't break activation
   try {

--- a/src/npm-model.ts
+++ b/src/npm-model.ts
@@ -1,19 +1,19 @@
 // Used for the data than comes from npm list --json
 export interface NpmPackage {
   // Version number in the package.json
-  version: string;
+  version?: string;
 
   // Name in package.json
-  name: string;
+  name?: string;
 
   // This is an object with properties for each package.
   // eg { "@capacitor/project": {"version": "1.0.31", "resolved": "https://registry.npmjs.org/@capacitor/project/-/project-1.0.31.tgz"}}
-  dependencies: object;
+  dependencies?: Record<string, NpmDependency>;
 }
 
 export interface NpmDependency {
   version: string; // Version number
-  resolved: string; // URL to the package
+  resolved?: string; // URL to the package
 }
 
 // Used from npm outdated --json

--- a/src/package-lock.ts
+++ b/src/package-lock.ts
@@ -9,7 +9,7 @@ export function hasPackageLock(project: Project): boolean {
   return existsSync(join(project.projectFolder(), 'package-lock.json'));
 }
 
-export function getVersionsFromPackageLock(project: Project): NpmPackage {
+export function getVersionsFromPackageLock(project: Project): NpmPackage | undefined {
   if (project.packageManager != PackageManager.npm) return undefined;
   const lockFile = join(project.projectFolder(), 'package-lock.json');
   if (!existsSync(lockFile)) return undefined;
@@ -17,7 +17,7 @@ export function getVersionsFromPackageLock(project: Project): NpmPackage {
   tStart(command);
   const txt = readFileSync(lockFile, { encoding: 'utf8' });
   const data = JSON.parse(txt);
-  const result = {};
+  const result: Record<string, { version: string }> = {};
   try {
     const packages = data.packages[''];
     for (const dep of [...Object.keys(packages.dependencies), ...Object.keys(packages.devDependencies)]) {

--- a/src/process-packages.ts
+++ b/src/process-packages.ts
@@ -29,6 +29,35 @@ interface PluginInformation {
   hasHooks: boolean;
 }
 
+interface ProcessedPackage {
+  version: string;
+  current?: string;
+  wanted?: string;
+  latest?: string;
+  isDevDependency?: boolean;
+  depType: string;
+  plugin?: PluginInformation;
+  deprecated?: string;
+  updated?: string;
+  description?: string;
+  isOld?: boolean;
+  url?: string;
+}
+
+type ProcessedPackages = Record<string, ProcessedPackage>;
+type DependencyMap = Record<string, string>;
+
+function asErrorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Prevents overlapping npm outdated/list runs for the same workspace. */
+const packageRefreshInFlight = new Set<string>();
+
+function packageRefreshKey(project: Project, folder: string): string {
+  return project?.monoRepo?.name ?? project.folder ?? folder;
+}
+
 export function clearRefreshCache(context: ExtensionContext) {
   if (context) {
     for (const key of context.workspaceState.keys()) {
@@ -41,6 +70,9 @@ export function clearRefreshCache(context: ExtensionContext) {
       if (key.startsWith(CapProjectCache(undefined))) {
         context.workspaceState.update(key, undefined);
       }
+      if (key.startsWith(PackageCacheRefreshedAt(undefined))) {
+        context.workspaceState.update(key, undefined);
+      }
       if (key == LastManifestCheck) {
         context.workspaceState.update(key, undefined);
       }
@@ -50,14 +82,18 @@ export function clearRefreshCache(context: ExtensionContext) {
   console.log('Cached data cleared');
 }
 
-async function runListPackages(project: Project, folder: string, context: ExtensionContext): Promise<string> {
+async function runListPackages(
+  project: Project,
+  folder: string,
+  context: ExtensionContext,
+): Promise<string | undefined> {
   const listOutput = getVersionsFromPackageLock(project);
   if (listOutput) {
     return JSON.stringify(listOutput);
   }
   const listCmd = listCommand(project);
   try {
-    const shell = isWindows ? 'powershell.exe' : undefined;
+    const shell = isWindows() ? 'powershell.exe' : undefined;
     let data = await getRunOutput(listCmd, folder, shell, true);
     if (project.isModernYarn()) {
       data = fixModernYarnList(data);
@@ -65,7 +101,8 @@ async function runListPackages(project: Project, folder: string, context: Extens
     return data;
   } catch (reason) {
     write(`> ${listCmd}`);
-    writeError(reason);
+    writeError(asErrorText(reason));
+    return undefined;
   }
 }
 
@@ -74,7 +111,14 @@ async function runListPackages(project: Project, folder: string, context: Extens
  * Safe to call without await for background refresh.
  */
 async function refreshPackageData(project: Project, folder: string, context: ExtensionContext): Promise<void> {
+  const key = packageRefreshKey(project, folder);
+  if (packageRefreshInFlight.has(key)) {
+    return;
+  }
+  packageRefreshInFlight.add(key);
+
   const outdatedCmd = outdatedCommand(project);
+  const selectedProject = context.workspaceState.get('SelectedProject');
   try {
     const [, freshVersions] = await Promise.all([
       getRunOutput(outdatedCmd, folder, undefined, true, true)
@@ -88,7 +132,7 @@ async function refreshPackageData(project: Project, folder: string, context: Ext
         })
         .catch((reason) => {
           write(`> ${outdatedCmd}`);
-          writeError(reason);
+          writeError(asErrorText(reason));
         }),
       runListPackages(project, folder, context),
     ]);
@@ -99,8 +143,15 @@ async function refreshPackageData(project: Project, folder: string, context: Ext
     }
     context.workspaceState.update(PackageCacheModified(project), project.modified.toUTCString());
     context.workspaceState.update(PackageCacheRefreshedAt(project), Date.now());
+    if ((selectedProject ?? '') === (project?.monoRepo?.name ?? '')) {
+      exState.refreshTree?.();
+    } else if (!selectedProject && exState.workspace === key) {
+      exState.refreshTree?.();
+    }
   } catch (err) {
-    if (err && err.includes('401')) {
+    // Record the attempt so an empty/failed list result does not immediately re-trigger refresh.
+    context.workspaceState.update(PackageCacheRefreshedAt(project), Date.now());
+    if (asErrorText(err).includes('401')) {
       window.showInformationMessage(
         `Unable to run '${outdatedCommand(project)}' due to authentication error. Check .npmrc`,
         'OK',
@@ -113,27 +164,29 @@ async function refreshPackageData(project: Project, folder: string, context: Ext
       writeError(`Unable to run '${outdatedCommand(project)}'. Try reinstalling node modules.`);
       console.error(err);
     }
+  } finally {
+    packageRefreshInFlight.delete(key);
   }
 }
 
 export async function processPackages(
   folder: string,
-  allDependencies: object,
-  devDependencies: object,
+  allDependencies: DependencyMap,
+  devDependencies: DependencyMap,
   context: ExtensionContext,
   project: Project,
-): Promise<any> {
+): Promise<ProcessedPackages> {
   if (!lstatSync(folder).isDirectory()) {
     return {};
   }
   // npm outdated only shows dependencies and not dev dependencies if the node module isn't installed
-  let outdated = '[]';
-  let versions = '{}';
+  let outdated: string | undefined = '[]';
+  let versions: string | undefined = '{}';
   try {
     const packagesModified: Date = project.modified;
     const packageModifiedLast = context.workspaceState.get(PackageCacheModified(project));
-    outdated = context.workspaceState.get(PackageCacheOutdated(project));
-    versions = context.workspaceState.get(PackageCacheList(project));
+    outdated = context.workspaceState.get<string>(PackageCacheOutdated(project));
+    versions = context.workspaceState.get<string>(PackageCacheList(project));
     const changed = packagesModified.toUTCString() != packageModifiedLast;
     if (changed) {
       exState.syncDone = [];
@@ -143,17 +196,14 @@ export async function processPackages(
     const lastRefreshedAt: number = context.workspaceState.get(PackageCacheRefreshedAt(project)) ?? 0;
     const oneHourMs = 60 * 60 * 1000;
     const refreshIsStale = Date.now() - lastRefreshedAt > oneHourMs;
-    // versions with length <= 2 is '{}' or '' - treat as unusable, needs a refresh
+    // versions with length <= 2 is '{}' or '' - only force a refresh if we have never attempted one
     const versionsUnusable = !versions || versions.length <= 2;
+    const neverRefreshed = lastRefreshedAt === 0;
+    const key = packageRefreshKey(project, folder);
+    const alreadyRefreshing = packageRefreshInFlight.has(key);
 
-    if (!hasCachedData) {
-      // No cache at all - must block and wait for fresh data on first run
-      await refreshPackageData(project, folder, context);
-      outdated = context.workspaceState.get(PackageCacheOutdated(project)) ?? '[]';
-      versions = context.workspaceState.get(PackageCacheList(project)) ?? '{}';
-    } else if (changed || refreshIsStale || versionsUnusable) {
-      // Cache exists but package.json changed, data is over 1 hour old, or versions is empty -
-      // return stale cache now and refresh in background
+    if (!alreadyRefreshing && (!hasCachedData || changed || refreshIsStale || (versionsUnusable && neverRefreshed))) {
+      // Return current project info immediately; fetch package freshness in the background.
       refreshPackageData(project, folder, context).catch((err) =>
         console.error('Background package refresh failed', err),
       );
@@ -161,7 +211,7 @@ export async function processPackages(
   } catch (err) {
     outdated = '[]';
     versions = '{}';
-    if (err && err.includes('401')) {
+    if (asErrorText(err).includes('401')) {
       window.showInformationMessage(
         `Unable to run '${outdatedCommand(project)}' due to authentication error. Check .npmrc`,
         'OK',
@@ -182,19 +232,19 @@ export async function processPackages(
 
   const packages = processDependencies(
     allDependencies,
-    getOutdatedData(outdated),
+    getOutdatedData(outdated ?? '[]'),
     devDependencies,
-    getListData(versions),
+    getListData(versions ?? '{}'),
   );
   inspectPackages(project.projectFolder() ? project.projectFolder() : folder, packages);
   return packages;
 }
 
-function getOutdatedData(outdated: string): any {
+function getOutdatedData(outdated: string): Record<string, NpmOutdatedDependency> {
   try {
     return JSON.parse(stripJSON(outdated, '{'));
   } catch {
-    return [];
+    return {};
   }
 }
 
@@ -202,11 +252,11 @@ function getListData(list: string): NpmPackage {
   try {
     return JSON.parse(list);
   } catch {
-    return { name: undefined, dependencies: undefined, version: undefined };
+    return { name: '', dependencies: {}, version: '' };
   }
 }
 
-export function reviewPackages(packages: object, project: Project) {
+export function reviewPackages(packages: ProcessedPackages, project: Project) {
   if (!packages || Object.keys(packages).length == 0) return;
 
   listPackages(project, 'Packages', `Your project relies on these packages.`, packages, [PackageType.Dependency]);
@@ -231,8 +281,8 @@ export function reviewPackages(packages: object, project: Project) {
 }
 
 // List any plugins that use Cordova Hooks as potential issue
-export function reviewPluginsWithHooks(packages: object): Tip[] {
-  const tips = [];
+export function reviewPluginsWithHooks(packages: ProcessedPackages): Tip[] {
+  const tips: Tip[] = [];
   // List of packages that don't need to be reported to the user because they would be dropped in a Capacitor migration
   // Using a Set for O(1) lookups instead of an array with O(n) includes() method
   const dontReportSet = new Set([
@@ -244,7 +294,7 @@ export function reviewPluginsWithHooks(packages: object): Tip[] {
     'cordova-plugin-push', // This has a hook for browser which is not applicable
   ]);
 
-  if (Object.keys(packages).length == 0) return;
+  if (Object.keys(packages).length == 0) return tips;
   for (const library of Object.keys(packages)) {
     if (
       packages[library].plugin &&
@@ -313,7 +363,7 @@ function markIfPlugin(folder: string): boolean {
   return false;
 }
 
-function markDeprecated(lockFile: string, packages) {
+function markDeprecated(lockFile: string, packages: ProcessedPackages) {
   const txt = readFileSync(lockFile, { encoding: 'utf8' });
   const data = JSON.parse(txt);
   if (!data.packages) {
@@ -330,7 +380,7 @@ function markDeprecated(lockFile: string, packages) {
   }
 }
 
-function inspectPackages(folder: string, packages) {
+function inspectPackages(folder: string, packages: ProcessedPackages) {
   // Use package-lock.json for deprecated packages
   const lockFile = join(folder, 'package-lock.json');
   if (existsSync(lockFile)) {
@@ -407,7 +457,12 @@ function inspectPackages(folder: string, packages) {
 }
 
 function processPlugin(content: string): PluginInformation {
-  const result = { androidPermissions: [], androidFeatures: [], dependentPlugins: [], hasHooks: false };
+  const result: PluginInformation = {
+    androidPermissions: [],
+    androidFeatures: [],
+    dependentPlugins: [],
+    hasHooks: false,
+  };
   if (content == '') {
     return result;
   }
@@ -430,9 +485,9 @@ function processPlugin(content: string): PluginInformation {
   return result;
 }
 
-function findAll(content, search: string, endsearch: string): Array<any> {
+function findAll(content: string, search: string, endsearch: string): string[] {
   const list = Array.from(content.matchAll(new RegExp(search + '(.*?)' + endsearch, 'g')));
-  const result = [];
+  const result: string[] = [];
   if (!list) return result;
   for (const item of list) {
     result.push(item[1]);
@@ -444,7 +499,7 @@ function listPackages(
   project: Project,
   title: string,
   description: string,
-  packages: object,
+  packages: ProcessedPackages,
   depTypes: Array<string>,
   tipType?: TipType,
 ) {
@@ -457,7 +512,7 @@ function listPackages(
     project.setGroup(`${count} ${title}`, description, tipType, undefined, 'packages');
   }
 
-  let lastScope: string;
+  let lastScope: string | undefined;
   for (const library of Object.keys(packages).sort()) {
     if (depTypes.includes(packages[library].depType)) {
       let v = `${packages[library].version}`;
@@ -477,7 +532,7 @@ function listPackages(
             //
             latest = packages['@angular/core']?.latest;
           }
-          project.addSubGroup(scope, latest);
+          project.addSubGroup(scope, latest ?? '');
           lastScope = scope;
         } else {
           project.clearSubgroup();
@@ -488,8 +543,9 @@ function listPackages(
       if (scope) {
         libraryTitle = library.substring(scope.length + 2);
       }
-      if (v != packages[library].latest && packages[library].latest !== PackageVersion.Unknown) {
-        project.upgrade(library, libraryTitle, `${v} → ${packages[library].latest}`, v, packages[library].latest, type);
+      const pkgLatest = packages[library].latest;
+      if (pkgLatest && v != pkgLatest && pkgLatest !== PackageVersion.Unknown) {
+        project.upgrade(library, libraryTitle, `${v} → ${pkgLatest}`, v, pkgLatest, type);
       } else {
         project.package(library, libraryTitle, `${v}`, type);
       }
@@ -498,10 +554,15 @@ function listPackages(
   project.clearSubgroup();
 }
 
-function processDependencies(allDependencies: object, outdated: object, devDependencies: object, list: NpmPackage) {
-  const packages = {};
+function processDependencies(
+  allDependencies: DependencyMap,
+  outdated: Record<string, NpmOutdatedDependency>,
+  devDependencies: DependencyMap,
+  list: NpmPackage,
+): ProcessedPackages {
+  const packages: ProcessedPackages = {};
   for (const library of Object.keys(allDependencies)) {
-    const dep: NpmDependency = list.dependencies ? list.dependencies[library] : undefined;
+    const dep: NpmDependency | undefined = list.dependencies?.[library];
     let version = dep ? dep.version : `${coerce(allDependencies[library])}`;
     if (allDependencies[library]?.startsWith('git') || allDependencies[library]?.startsWith('file')) {
       version = PackageVersion.Custom;

--- a/src/tree-provider.ts
+++ b/src/tree-provider.ts
@@ -24,15 +24,15 @@ import { join } from 'path';
 import { StarterPanel } from './starter';
 
 interface ExState {
-  view: TreeView<any>;
+  view?: TreeView<any>;
   skipAuth: boolean;
   projects: Array<MonoRepoProject>;
   repoType: MonoRepoType;
   packageManager: PackageManager;
-  workspace: string; // Monorepo workspace name
-  context: ExtensionContext;
+  workspace?: string; // Monorepo workspace name
+  context?: ExtensionContext;
   shell?: string;
-  projectsView: TreeView<any>;
+  projectsView?: TreeView<any>;
   selectedAndroidDevice?: string;
   selectedIOSDevice?: string;
   selectedAndroidDeviceName?: string;
@@ -43,31 +43,32 @@ interface ExState {
   channelFocus: boolean; // Whether to focus the output window
   refreshDebugDevices: boolean; // Should we refresh the list of debuggable devices
   remoteLogging: boolean; // Whether remote logging is enabled
-  hasNodeModules: boolean; // Whether node modules are installed
-  nodeModulesFolder: string; // The folder where node_modules is located
-  hasPackageJson: boolean; // Whether folder has package.json
-  hasNodeModulesNotified: boolean; // Whether we've notified the user of no node_modules
-  buildConfiguration: string; // Build configuration
-  runConfiguration: string; // Run configuration
-  project: string; // Angular project name
-  nvm: string; // If .nvmrc is used will contain its contents
-  rootFolder: string; // The folder to inspect
-  flavors: string[]; // Android Flavors
+  hasNodeModules?: boolean; // Whether node modules are installed
+  nodeModulesFolder?: string; // The folder where node_modules is located
+  hasPackageJson?: boolean; // Whether folder has package.json
+  hasNodeModulesNotified?: boolean; // Whether we've notified the user of no node_modules
+  buildConfiguration?: string; // Build configuration
+  runConfiguration?: string; // Run configuration
+  project?: string; // Angular project name
+  nvm?: string; // If .nvmrc is used will contain its contents
+  rootFolder?: string; // The folder to inspect
+  flavors?: string[]; // Android Flavors
   debugged: boolean; // Have we ever started debugging
   servePort: number; // The port used when the dev server is running
   webView: WebviewPanel | undefined; // The Web Browser preview
-  runIOS: Tip;
-  runAndroid: Tip;
-  runWeb: Tip;
-  lastRun: CapacitorPlatform;
+  runIOS?: Tip;
+  runAndroid?: Tip;
+  runWeb?: Tip;
+  lastRun?: CapacitorPlatform;
   lastAutoRun?: string; // Last command that automatically run via clipboard
-  projectRef: Project;
+  projectRef?: Project;
   runStatusBar: StatusBarItem | undefined;
   openWebStatusBar: StatusBarItem | undefined;
   openEditorStatusBar: StatusBarItem | undefined;
   localUrl: string | undefined; // URL for the local browser
   externalUrl: string | undefined; // URL for the external browser
   dontOpenBrowser: boolean; // If true then avoid opening the browser
+  refreshTree?: () => void; // Soft-refresh the tree without clearing package caches
 }
 
 export const exState: ExState = {
@@ -116,7 +117,7 @@ interface FolderInfo {
   folder: string;
 }
 
-let folderInfoCache: FolderInfo = undefined;
+let folderInfoCache: FolderInfo | undefined;
 
 export class ExTreeProvider implements TreeDataProvider<Recommendation> {
   private _onDidChangeTreeData: EventEmitter<Recommendation | undefined | void> = new EventEmitter<
@@ -124,7 +125,7 @@ export class ExTreeProvider implements TreeDataProvider<Recommendation> {
   >();
   readonly onDidChangeTreeData: Event<Recommendation | undefined | void> = this._onDidChangeTreeData.event;
 
-  selectedProject: string;
+  selectedProject: string | undefined;
 
   constructor(
     private workspaceRoot: string | undefined,
@@ -162,26 +163,28 @@ export class ExTreeProvider implements TreeDataProvider<Recommendation> {
         return Promise.resolve(element.children);
       }
     } else {
-      let folderInfo: FolderInfo = folderInfoCache;
+      let folderInfo: FolderInfo | undefined = folderInfoCache;
       if (!folderInfo || folderInfo.folder != this.workspaceRoot || !folderInfo.packageJsonExists) {
         folderInfo = this.getFolderInfo(this.workspaceRoot);
         folderInfoCache = folderInfo;
       }
       if (folderInfo.packageJsonExists || folderInfo.folderBased) {
-        const summary = await reviewProject(this.workspaceRoot, this.context, this.selectedProject);
+        const summary = await reviewProject(this.workspaceRoot, this.context, this.selectedProject ?? '');
 
         if (!summary) return [];
         return summary.project.groups;
       } else {
-        StarterPanel.init(exState.context.extensionUri, this.workspaceRoot, exState.context);
+        if (exState.context) {
+          StarterPanel.init(exState.context.extensionUri, this.workspaceRoot, exState.context);
+        }
         return Promise.resolve([]);
       }
     }
   }
 
   private getFolderInfo(folder: string): FolderInfo {
-    const packageJsonPath = join(this.workspaceRoot, 'package.json');
-    const folders = isFolderBasedMonoRepo(this.workspaceRoot);
+    const packageJsonPath = join(folder, 'package.json');
+    const folders = isFolderBasedMonoRepo(folder);
     const packageJsonExists = this.pathExists(packageJsonPath);
     const folderBased = folders.length > 0 && !packageJsonExists;
 


### PR DESCRIPTION
## Summary

This PR updates the extension version to **2.2.10** and improves package refresh behavior and TypeScript safety across package-processing and tree-provider code.

## Changes

### Versioning
- Bump `package.json` version from **2.2.9** to **2.2.10**
- Update `CHANGELOG.md` with the 2.2.10 release notes
- Refresh lockfile metadata to match the package version update

### Package refresh and cache behavior
- Prevent repeated `npm outdated` / `npm list` refresh loops by deduplicating in-flight package refreshes
- Avoid re-triggering refreshes solely because the cached package list is empty after a recent attempt
- Return project inspection results immediately, then perform outdated package checks in a second background pass
- Cache background refreshes per selected workspace and trigger a UI refresh when updated package data arrives
- Allow package/project cache key helpers to be called without a `Project`, enabling broader cache clearing by workspace prefix

### TypeScript safety improvements
- Fix tree-provider typing issues by making lazily initialized `ExState` fields optional
- Tighten typing in package-processing logic, including:
  - stricter typing for package maps
  - improved error handling
  - support for optional `Project` arguments in cache-key helpers

## Why

These changes are intended to make dependency inspection more reliable and responsive while also resolving TypeScript issues in stricter code paths. In particular, they reduce unnecessary refresh churn, improve cache invalidation behavior for workspace-scoped data, and strengthen type safety in the package-processing flow.