### PR TITLE
Fix Angular migration recommendations and update prompt behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 2.2.14
+
+- Fix @angular light bulb so projects already on the latest major still get “Update to latest v{N}”
+
 ### Version 2.2.13
 
 - Angular optional migrations added to project menu

--- a/src/project.ts
+++ b/src/project.ts
@@ -369,12 +369,14 @@ export class Project {
 
   public addSubGroup(title: string, latestVersion: string) {
     let tip: Tip = undefined;
+    let showLightbulb = true;
     if (title == 'angular') {
       // Option to upgrade with:
       // ng update @angular/cli@13 @angular/core@13 --allow-dirty
-      tip = angularMigrate(this, latestVersion ?? maxAngularVersion);
+      tip = angularMigrate(this, latestVersion || maxAngularVersion);
       if (!tip) {
         tip = new Tip('Angular Packages', '', TipType.Angular);
+        showLightbulb = false;
       }
     } else {
       tip = new Tip('Upgrade All Packages', undefined, TipType.Run, undefined, undefined, 'Upgrade');
@@ -388,10 +390,10 @@ export class Project {
 
     const r = new Recommendation(tip.title, undefined, '@' + title, TreeItemCollapsibleState.Expanded, command, tip);
     r.children = [];
-    if (title == 'angular') {
+    if (showLightbulb) {
       r.setContext(Context.lightbulb);
-    } else {
-      r.setContext(Context.lightbulb);
+    }
+    if (title != 'angular') {
       r.tip.setDynamicCommand(this.updatePackages, r).setDynamicTitle(this.updatePackagesTitle, r);
     }
 

--- a/src/rules-angular-migrate.ts
+++ b/src/rules-angular-migrate.ts
@@ -31,38 +31,36 @@ export function addAngularMigrationRecommendation(project: Project): void {
   }
 }
 
-export function angularMigrate(project: Project, latestVersion: string): Tip | undefined {
+export function angularMigrate(project: Project, latestVersion?: string): Tip | undefined {
   const current = getPackageVersion('@angular/core');
-  const max = coerce(maxAngularVersion);
+  const max = coerce(latestVersion || maxAngularVersion);
   if (!current || !max) {
     return;
   }
-  if (current.major >= max.major) {
+  // Do not offer migrations beyond the highest version we support
+  if (current.major > max.major) {
     return;
   }
-  const next = current.major + 1;
-  if (next > max.major) {
-    return;
-  }
-  return new Tip(`Migrate to Angular ${next}`, '', TipType.Angular).setQueuedAction(
-    migrate,
-    project,
-    next,
-    current.major,
-    current.version,
-  );
+
+  // Prefer the next major when available; otherwise stay on the current major so
+  // the light bulb can still offer "Update to latest v{current}".
+  const next = current.major < max.major ? current.major + 1 : current.major;
+  const title = next > current.major ? `Migrate to Angular ${next}` : `Update Angular ${current.major}`;
+  return new Tip(title, '', TipType.Angular).setQueuedAction(migrate, project, next, current.major, current.version);
 }
 
 async function migrate(queueFunction: QueueFunction, project: Project, next: number, current: number, now: string) {
+  const canMigrateToNext = next > current;
   const nextButton = `Update to v${next}`;
   const currentButton = `Update to latest v${current}`;
   const infoButton = 'Info';
-  const result = await window.showInformationMessage(
-    `Would you like to migrate from Angular ${now} to ${next}? This will use 'ng update': Make sure you have committed your code before you begin.`,
-    infoButton,
-    currentButton,
-    nextButton,
-  );
+  const message = canMigrateToNext
+    ? `Would you like to migrate from Angular ${now} to ${next}? This will use 'ng update': Make sure you have committed your code before you begin.`
+    : `Would you like to update to the latest Angular ${current}? This will use 'ng update': Make sure you have committed your code before you begin.`;
+
+  const result = canMigrateToNext
+    ? await window.showInformationMessage(message, infoButton, currentButton, nextButton)
+    : await window.showInformationMessage(message, infoButton, currentButton);
   if (!result) return;
   switch (result) {
     case infoButton:


### PR DESCRIPTION
## Summary

This PR improves Angular upgrade recommendations and bumps the extension version to **2.2.14**.

## Changes

### Angular migration/update recommendations
- Fixes the Angular light bulb behavior so projects already on the latest supported **major** version still receive the correct prompt to update to the latest release within that major version.
- Updates Angular migration recommendation logic to:
  - use the provided latest Angular version when available
  - avoid առաջարկing migrations beyond the highest supported Angular version
  - recommend the **next major version** when applicable
  - fall back to the **current major version** when the project is already on the latest supported major, so users still get an update prompt

### UI behavior
- Adjusts subgroup/light bulb handling for Angular projects so the light bulb is only shown when there is a valid Angular migration/update recommendation.

### Versioning and changelog
- Bumps the package version to **2.2.14**
- Adds a changelog entry describing the Angular light bulb fix

## Why

These changes ensure Angular users get more accurate and useful upgrade guidance, especially when they are already on the latest supported major version but still need to update to the latest version within that major.